### PR TITLE
Updated Upstream (Waterfall)

### DIFF
--- a/Waterfall-Proxy-Patches/0001-POM-changes-and-rebranding.patch
+++ b/Waterfall-Proxy-Patches/0001-POM-changes-and-rebranding.patch
@@ -322,7 +322,7 @@ index 652a869d5bbc2d323fc84bd9f0dcf1d830f7757c..b2aca1998b58ca53744862f2810a6213
      <dependencies>
          <dependency>
 diff --git a/pom.xml b/pom.xml
-index fd71cdbddb95e31ededd4b85058f96995ec6fec1..91e48b3d7b7bf95cd884fb5c4809bd42f7ae51af 100644
+index 8d86e36c722fb25ef5c6ffca601b27eea89c8f5d..0c070a36fe3725bb2f14c7aa570d3a0f46b36967 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -3,26 +3,18 @@
@@ -446,7 +446,7 @@ index fd71cdbddb95e31ededd4b85058f96995ec6fec1..91e48b3d7b7bf95cd884fb5c4809bd42
              <scope>compile</scope>
          </dependency>
          <dependency>
-@@ -355,7 +344,7 @@
+@@ -356,7 +345,7 @@
                      <plugin>
                          <groupId>org.projectlombok</groupId>
                          <artifactId>lombok-maven-plugin</artifactId>
@@ -455,7 +455,7 @@ index fd71cdbddb95e31ededd4b85058f96995ec6fec1..91e48b3d7b7bf95cd884fb5c4809bd42
                          <executions>
                              <execution>
                                  <id>delombok</id>
-@@ -373,9 +362,10 @@
+@@ -374,9 +363,10 @@
                      <plugin>
                          <groupId>org.apache.maven.plugins</groupId>
                          <artifactId>maven-javadoc-plugin</artifactId>
@@ -578,7 +578,7 @@ index c3a2eeb6fa11d47affc1b7d83c3cc847531ad955..4578ba40a4ca2e7ad0a7909e248221ff
              <scope>compile</scope>
          </dependency>
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index c09f5b4c39b4e5514e77f815ec0299de753881da..91f04d85207fe5ac7f74a4d9f2c3470b1370601e 100644
+index 07d74c67388d93a48a56d4d8554f194dd47c3104..7580209382665f30a7983fa23dd1890634555303 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -188,7 +188,7 @@ public class BungeeCord extends ProxyServer
@@ -600,10 +600,10 @@ index c09f5b4c39b4e5514e77f815ec0299de753881da..91f04d85207fe5ac7f74a4d9f2c3470b
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
-index 35680528553b04097a714c9dc5de9d3484de5416..51615fed5d3f6d050390610f2283877b1a6419a3 100644
+index 0db3d76ae0676f2e5716c726eca4e042b34550ac..074fefc87a22fb4495dac9a2bb7e4a7c4d8fe6b5 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
-@@ -67,7 +67,7 @@ public class BungeeCordLauncher
+@@ -54,7 +54,7 @@ public class BungeeCordLauncher
              if ( buildDate.before( deadline.getTime() ) )
              {
                  System.err.println( "*** Hey! This build is potentially outdated :( ***" );
@@ -612,7 +612,7 @@ index 35680528553b04097a714c9dc5de9d3484de5416..51615fed5d3f6d050390610f2283877b
                  System.err.println( "*** Should this build be outdated, you will get NO support for it. ***" );
                  System.err.println( "*** Server will start in 10 seconds ***" );
                  Thread.sleep( TimeUnit.SECONDS.toMillis( 10 ) );
-@@ -76,8 +76,8 @@ public class BungeeCordLauncher
+@@ -63,8 +63,8 @@ public class BungeeCordLauncher
  
          BungeeCord bungee = new BungeeCord();
          ProxyServer.setInstance( bungee );

--- a/Waterfall-Proxy-Patches/0002-Get-rid-of-modules.patch
+++ b/Waterfall-Proxy-Patches/0002-Get-rid-of-modules.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Get rid of modules
 
 
 diff --git a/pom.xml b/pom.xml
-index 91e48b3d7b7bf95cd884fb5c4809bd42f7ae51af..77dd0268ea2c9fa1fb8bb6344f358f93ce3c5e4c 100644
+index 0c070a36fe3725bb2f14c7aa570d3a0f46b36967..73fd6bbfee16bb9354e2e6bbb370d720ad946903 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -39,7 +39,9 @@
@@ -691,7 +691,7 @@ index 0000000000000000000000000000000000000000..4915d8d7b55c1f6d16ad55024ec807a2
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 91f04d85207fe5ac7f74a4d9f2c3470b1370601e..b4495e9b7646568cdf0f2065f61ab85f4b0ce9d6 100644
+index 7580209382665f30a7983fa23dd1890634555303..6248e7dd2d9c49ae24d35093d30690ddb8260bbf 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -94,6 +94,15 @@ import net.md_5.bungee.query.RemoteQuery;

--- a/Waterfall-Proxy-Patches/0003-Misc-changes.patch
+++ b/Waterfall-Proxy-Patches/0003-Misc-changes.patch
@@ -154,7 +154,7 @@ index a42d63fa881628e4bb3f6ceae8c9676e9e614b47..e0c37b1ec429db823401a7e8ce338c0c
                      <PatternMatch key=",BungeeCord" pattern="[%d{HH:mm:ss}] [%t/%level]: %paperMinecraftFormatting{%msg}{strip}%n" />
                  </LoggerNamePatternSelector>
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index b4495e9b7646568cdf0f2065f61ab85f4b0ce9d6..bd1192caa150156fd1832ff609f3d5874e7cb4a7 100644
+index 6248e7dd2d9c49ae24d35093d30690ddb8260bbf..e41fff8a7dce59d0ea007abe1ba07de59a157f06 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -511,8 +511,10 @@ public class BungeeCord extends ProxyServer
@@ -171,10 +171,10 @@ index b4495e9b7646568cdf0f2065f61ab85f4b0ce9d6..bd1192caa150156fd1832ff609f3d587
                      try {
                          bossEventLoopGroup.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
-index 51615fed5d3f6d050390610f2283877b1a6419a3..0a19f6d7346f282e98bd4d5ac781bd6c5ef0be95 100644
+index 074fefc87a22fb4495dac9a2bb7e4a7c4d8fe6b5..fdf32d89fdde0c2eb76a8d928e51c9ae71945e49 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
-@@ -75,6 +75,19 @@ public class BungeeCordLauncher
+@@ -62,6 +62,19 @@ public class BungeeCordLauncher
          }
  
          BungeeCord bungee = new BungeeCord();
@@ -213,10 +213,10 @@ index a5efb0af281a39da79383b8bf7e3e86974212c5c..4ed248558c1549fdef2ba6bb687341a8
              // Update debug info from login packet
              user.unsafe().sendPacket( new EntityStatus( user.getClientEntityId(), login.isReducedDebugInfo() ? EntityStatus.DEBUG_INFO_REDUCED : EntityStatus.DEBUG_INFO_NORMAL ) );
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 6d974d7465a981db7c8cdbcff7d3252826d587cf..d515d401920e72400846b48a6c8e8548cb218e31 100644
+index fc98b4b19110ca5a45cfe473c2491504c0e40cde..aa7056dc3060fe7b70f3ffe28965522683b2f218 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -322,7 +322,7 @@ public final class UserConnection implements ProxiedPlayer
+@@ -323,7 +323,7 @@ public final class UserConnection implements ProxiedPlayer
              {
                  callback.done( ServerConnectRequest.Result.ALREADY_CONNECTED, null );
              }
@@ -225,7 +225,7 @@ index 6d974d7465a981db7c8cdbcff7d3252826d587cf..d515d401920e72400846b48a6c8e8548
              sendMessage( bungee.getTranslation( "already_connected" ) );
              return;
          }
-@@ -332,7 +332,7 @@ public final class UserConnection implements ProxiedPlayer
+@@ -333,7 +333,7 @@ public final class UserConnection implements ProxiedPlayer
              {
                  callback.done( ServerConnectRequest.Result.ALREADY_CONNECTING, null );
              }
@@ -234,7 +234,7 @@ index 6d974d7465a981db7c8cdbcff7d3252826d587cf..d515d401920e72400846b48a6c8e8548
              sendMessage( bungee.getTranslation( "already_connecting" ) );
              return;
          }
-@@ -415,6 +415,9 @@ public final class UserConnection implements ProxiedPlayer
+@@ -427,6 +427,9 @@ public final class UserConnection implements ProxiedPlayer
  
      public void disconnect0(final BaseComponent... reason)
      {
@@ -244,7 +244,7 @@ index 6d974d7465a981db7c8cdbcff7d3252826d587cf..d515d401920e72400846b48a6c8e8548
          if ( !ch.isClosing() )
          {
              bungee.getLogger().log( Level.INFO, "[{0}] disconnected with: {1}", new Object[]
-@@ -730,6 +733,14 @@ public final class UserConnection implements ProxiedPlayer
+@@ -742,6 +745,14 @@ public final class UserConnection implements ProxiedPlayer
          title.send( this );
      }
  
@@ -273,10 +273,10 @@ index 65b03ad62b9584e3a05fcc1362ee1adbd07bfdd1..d326295182fc5be3711f27befc919f96
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/command/CommandEnd.java b/proxy/src/main/java/net/md_5/bungee/command/CommandEnd.java
-index d87d0b95f3e675fc7c8d7d18add037c7fe32eabc..055b3bb6ebabec81862071e254d57ca4d368cd4f 100644
+index 03feeb3902def1b244f87ede42222f3d8e99c8e0..6048a274d27fb27a3c9586f5c324416f3064e8a1 100644
 --- a/proxy/src/main/java/net/md_5/bungee/command/CommandEnd.java
 +++ b/proxy/src/main/java/net/md_5/bungee/command/CommandEnd.java
-@@ -14,7 +14,7 @@ public class CommandEnd extends Command
+@@ -15,7 +15,7 @@ public class CommandEnd extends Command
  
      public CommandEnd()
      {

--- a/Waterfall-Proxy-Patches/0004-Add-IvanCord-specific-configuration.patch
+++ b/Waterfall-Proxy-Patches/0004-Add-IvanCord-specific-configuration.patch
@@ -42,7 +42,7 @@ index 527f310e7d402c093528b79ce4f2f69eeeeef48b..b5750e142b213e07159f31e39254707c
      /**
       * Whether we log InitialHandler connections
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index bd1192caa150156fd1832ff609f3d5874e7cb4a7..bae9b3ed575ce50fe8a6c8c7f0a589b14bb70231 100644
+index e41fff8a7dce59d0ea007abe1ba07de59a157f06..99b325f0955f123ec611d4faf479c164fd078f56 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -117,7 +117,7 @@ public class BungeeCord extends ProxyServer

--- a/Waterfall-Proxy-Patches/0005-Kick-to-lobby-support.patch
+++ b/Waterfall-Proxy-Patches/0005-Kick-to-lobby-support.patch
@@ -114,11 +114,11 @@ index 9e180c30c05d946e892ae9fbd4d7d796e202d5d4..2c2427a6c2acf037cbb84b3a440e92cb
          throw CancelSendSignal.INSTANCE;
      }
 diff --git a/proxy/src/main/resources/messages.properties b/proxy/src/main/resources/messages.properties
-index 2a79e62b65a6e1f964793f732836a01bb6ee4ec4..e838024539689e7ff1109d116434ddc64c9e088f 100644
+index 0b7e74c967b271b037b8e5e7c90dbc881dcb4e9c..d0aa1b4c3ceb2902a31f1351472282ed2ab8f71f 100644
 --- a/proxy/src/main/resources/messages.properties
 +++ b/proxy/src/main/resources/messages.properties
-@@ -38,3 +38,4 @@ you_got_summoned=\u00a76Summoned to {0} by {1}
- command_perms_groups=\u00a76You have the following groups: {0}
+@@ -39,3 +39,4 @@ command_perms_groups=\u00a76You have the following groups: {0}
  command_perms_permission=\u00a79- {0}
  command_ip=\u00a79IP of {0} is {1}
+ illegal_chat_characters=\u00a7cillegal characters in chat ({0})
 +kick_to_lobby=You were kicked from server {0} with reason {1} . The fallback sent you to {2}

--- a/Waterfall-Proxy-Patches/0006-Remove-entity-rewrite.patch
+++ b/Waterfall-Proxy-Patches/0006-Remove-entity-rewrite.patch
@@ -320,10 +320,10 @@ index 4ed248558c1549fdef2ba6bb687341a89a0bf1c7..c7f7263e907e2d8c1737144dae9e0cc4
              user.unsafe().sendPacket( new Respawn( login.getDimension(), login.getWorldName(), login.getSeed(), login.getDifficulty(), login.getGameMode(), login.getPreviousGameMode(), login.getLevelType(), login.isDebug(), login.isFlat(), false ) );
              if ( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_14 )
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index d515d401920e72400846b48a6c8e8548cb218e31..efa74af492d8c88c13ca19de0d2b9757953ff2c7 100644
+index aa7056dc3060fe7b70f3ffe28965522683b2f218..4641de8796eebcaa81226c2a88cc08d2e35dbffb 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -126,15 +126,22 @@ public final class UserConnection implements ProxiedPlayer
+@@ -127,15 +127,22 @@ public final class UserConnection implements ProxiedPlayer
      private final Scoreboard serverSentScoreboard = new Scoreboard();
      @Getter
      private final Collection<UUID> sentBossBars = new HashSet<>();
@@ -346,7 +346,7 @@ index d515d401920e72400846b48a6c8e8548cb218e31..efa74af492d8c88c13ca19de0d2b9757
      private Locale locale;
      /*========================================================================*/
      @Getter
-@@ -155,10 +162,14 @@ public final class UserConnection implements ProxiedPlayer
+@@ -156,10 +163,14 @@ public final class UserConnection implements ProxiedPlayer
  
      public void init()
      {
@@ -361,7 +361,7 @@ index d515d401920e72400846b48a6c8e8548cb218e31..efa74af492d8c88c13ca19de0d2b9757
  
          this.displayName = name;
  
-@@ -763,14 +774,19 @@ public final class UserConnection implements ProxiedPlayer
+@@ -775,14 +786,19 @@ public final class UserConnection implements ProxiedPlayer
      }
  
      @Override
@@ -435,10 +435,10 @@ index 2c2427a6c2acf037cbb84b3a440e92cb64519352..0b7a7b4d880449a95fe2a5cf99844b5e
      @Override
      public void handle(Respawn respawn)
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 4d7b1b23e6394ea6a198a957c91e66596d567dee..60ae4c0a8076fff4c86240083debda4427b17294 100644
+index d93d885191a4ba3e4e81b191b156123c894c88c4..60512bd2f74e465f68dddd9bdc81a4a4302be633 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -118,11 +118,13 @@ public class UpstreamBridge extends PacketHandler
+@@ -117,11 +117,13 @@ public class UpstreamBridge extends PacketHandler
      {
          if ( con.getServer() != null )
          {

--- a/Waterfall-Proxy-Patches/0007-Add-player-positioning-api.patch
+++ b/Waterfall-Proxy-Patches/0007-Add-player-positioning-api.patch
@@ -256,10 +256,10 @@ index 0000000000000000000000000000000000000000..f23fe50e8c9a22ce934f5797f9e75fb2
 +}
 +// IvanCord end
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index efa74af492d8c88c13ca19de0d2b9757953ff2c7..d95cd1c011bad22612a1e65e890e23fc0afed4d2 100644
+index 4641de8796eebcaa81226c2a88cc08d2e35dbffb..a2a37ab133d9781e69bee98ac8ce03d70c541899 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -65,6 +65,7 @@ import net.md_5.bungee.tab.ServerUnique;
+@@ -66,6 +66,7 @@ import net.md_5.bungee.tab.ServerUnique;
  import net.md_5.bungee.tab.TabList;
  import net.md_5.bungee.util.CaseInsensitiveSet;
  import net.md_5.bungee.util.ChatComponentTransformer;
@@ -267,7 +267,7 @@ index efa74af492d8c88c13ca19de0d2b9757953ff2c7..d95cd1c011bad22612a1e65e890e23fc
  
  @RequiredArgsConstructor
  public final class UserConnection implements ProxiedPlayer
-@@ -105,6 +106,10 @@ public final class UserConnection implements ProxiedPlayer
+@@ -106,6 +107,10 @@ public final class UserConnection implements ProxiedPlayer
      @Getter
      @Setter
      private int gamemode;
@@ -278,7 +278,7 @@ index efa74af492d8c88c13ca19de0d2b9757953ff2c7..d95cd1c011bad22612a1e65e890e23fc
      @Getter
      private int compressionThreshold = -1;
      // Used for trying multiple servers in order
-@@ -649,6 +654,12 @@ public final class UserConnection implements ProxiedPlayer
+@@ -661,6 +666,12 @@ public final class UserConnection implements ProxiedPlayer
      {
          return ( settings != null ) ? settings.getViewDistance() : 10;
      }
@@ -364,10 +364,10 @@ index 0b7a7b4d880449a95fe2a5cf99844b5e7bc67144..409878ec8c403062d61a50ef3cb0f03b
      public String toString()
      {
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 60ae4c0a8076fff4c86240083debda4427b17294..1efdc559d3c90063946fe38d1ad4e53a99eb198a 100644
+index 60512bd2f74e465f68dddd9bdc81a4a4302be633..30e6cc6552a134bc5358414cbc93368f9bf63ca0 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -30,9 +30,11 @@ import net.md_5.bungee.protocol.packet.Chat;
+@@ -29,9 +29,11 @@ import net.md_5.bungee.protocol.packet.Chat;
  import net.md_5.bungee.protocol.packet.ClientSettings;
  import net.md_5.bungee.protocol.packet.KeepAlive;
  import net.md_5.bungee.protocol.packet.PlayerListItem;
@@ -379,7 +379,7 @@ index 60ae4c0a8076fff4c86240083debda4427b17294..1efdc559d3c90063946fe38d1ad4e53a
  
  public class UpstreamBridge extends PacketHandler
  {
-@@ -277,6 +279,14 @@ public class UpstreamBridge extends PacketHandler
+@@ -287,6 +289,14 @@ public class UpstreamBridge extends PacketHandler
          }
      }
  

--- a/Waterfall-Proxy-Patches/0008-Add-PlaySound-packet.patch
+++ b/Waterfall-Proxy-Patches/0008-Add-PlaySound-packet.patch
@@ -372,10 +372,10 @@ index c7f7263e907e2d8c1737144dae9e0cc44dfa9964..eb435bec0d69ef86c7391565e2197a43
      public void handle(LoginPayloadRequest loginPayloadRequest)
      {
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index d95cd1c011bad22612a1e65e890e23fc0afed4d2..b3810efbc4b22e9af74ba3e3a4fa88f16a743fee 100644
+index a2a37ab133d9781e69bee98ac8ce03d70c541899..509ea05c22f1031e52230076ca1ff99fe19dc9a9 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -58,6 +58,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
+@@ -59,6 +59,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
  import net.md_5.bungee.protocol.packet.Chat;
  import net.md_5.bungee.protocol.packet.ClientSettings;
  import net.md_5.bungee.protocol.packet.Kick;
@@ -383,7 +383,7 @@ index d95cd1c011bad22612a1e65e890e23fc0afed4d2..b3810efbc4b22e9af74ba3e3a4fa88f1
  import net.md_5.bungee.protocol.packet.PlayerListHeaderFooter;
  import net.md_5.bungee.protocol.packet.PluginMessage;
  import net.md_5.bungee.protocol.packet.SetCompression;
-@@ -66,6 +67,8 @@ import net.md_5.bungee.tab.TabList;
+@@ -67,6 +68,8 @@ import net.md_5.bungee.tab.TabList;
  import net.md_5.bungee.util.CaseInsensitiveSet;
  import net.md_5.bungee.util.ChatComponentTransformer;
  import com.mrivanplays.ivancord.api.Position; // IvanCord
@@ -392,7 +392,7 @@ index d95cd1c011bad22612a1e65e890e23fc0afed4d2..b3810efbc4b22e9af74ba3e3a4fa88f1
  
  @RequiredArgsConstructor
  public final class UserConnection implements ProxiedPlayer
-@@ -791,6 +794,31 @@ public final class UserConnection implements ProxiedPlayer
+@@ -803,6 +806,31 @@ public final class UserConnection implements ProxiedPlayer
          return serverSentScoreboard;
      }
  

--- a/Waterfall-Proxy-Patches/0009-Add-gplugins-command.patch
+++ b/Waterfall-Proxy-Patches/0009-Add-gplugins-command.patch
@@ -48,7 +48,7 @@ index 0000000000000000000000000000000000000000..5d6a1d0c22a94b049636c40fbbe3e9de
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index bae9b3ed575ce50fe8a6c8c7f0a589b14bb70231..1455814e19fd9fec8a8ca99ccaadeb1a7fc9c610 100644
+index 99b325f0955f123ec611d4faf479c164fd078f56..f5c364790be0cb7c36bb249d898385ffe47062c8 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -101,6 +101,7 @@ import com.mrivanplays.ivancord.modules.CommandFind;
@@ -85,11 +85,11 @@ index 69000b1ee51231aba28a3a85166c50372ff0355f..c52688dd376927d648638d8c531176b9
          }
  
 diff --git a/proxy/src/main/resources/messages.properties b/proxy/src/main/resources/messages.properties
-index e838024539689e7ff1109d116434ddc64c9e088f..55493ee39edcbd362ae43d7c748cadf80c98e7ab 100644
+index d0aa1b4c3ceb2902a31f1351472282ed2ab8f71f..35c2b9ff046eac2c20e5f66eb71b962a14ebda4a 100644
 --- a/proxy/src/main/resources/messages.properties
 +++ b/proxy/src/main/resources/messages.properties
-@@ -39,3 +39,4 @@ command_perms_groups=\u00a76You have the following groups: {0}
- command_perms_permission=\u00a79- {0}
+@@ -40,3 +40,4 @@ command_perms_permission=\u00a79- {0}
  command_ip=\u00a79IP of {0} is {1}
+ illegal_chat_characters=\u00a7cillegal characters in chat ({0})
  kick_to_lobby=You were kicked from server {0} with reason {1} . The fallback sent you to {2}
 +command_plugins_message=Plugins ({0}): {1}

--- a/Waterfall-Proxy-Patches/0011-Add-LoginCancelledEvent.patch
+++ b/Waterfall-Proxy-Patches/0011-Add-LoginCancelledEvent.patch
@@ -65,7 +65,7 @@ index 0000000000000000000000000000000000000000..f140b0195e9661e364dafab7c3aba7ec
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 08c49fcc6701d9e0abcce534fd8141ba858a5afa..ee1fcad3185cc9c0db40a2d58e28fdc07ab3b8ce 100644
+index 0f1716c091e42261119ca8a99837780ad7e8bbf3..f7331736e2cd604f35011a5ed8b0ab4cd8ba9374 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 @@ -67,6 +67,7 @@ import net.md_5.bungee.protocol.packet.StatusResponse;
@@ -86,7 +86,7 @@ index 08c49fcc6701d9e0abcce534fd8141ba858a5afa..ee1fcad3185cc9c0db40a2d58e28fdc0
      }
  
      @Override
-@@ -400,11 +404,17 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -394,11 +398,17 @@ public class InitialHandler extends PacketHandler implements PendingConnection
              {
                  if ( result.isCancelled() )
                  {
@@ -104,7 +104,7 @@ index 08c49fcc6701d9e0abcce534fd8141ba858a5afa..ee1fcad3185cc9c0db40a2d58e28fdc0
                      return;
                  }
                  if ( onlineMode )
-@@ -529,11 +539,17 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -523,11 +533,17 @@ public class InitialHandler extends PacketHandler implements PendingConnection
              {
                  if ( result.isCancelled() )
                  {
@@ -122,7 +122,7 @@ index 08c49fcc6701d9e0abcce534fd8141ba858a5afa..ee1fcad3185cc9c0db40a2d58e28fdc0
                      return;
                  }
  
-@@ -570,6 +586,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -564,6 +580,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
  
                              thisState = State.FINISHED;
                          }

--- a/Waterfall-Proxy-Patches/0012-Add-basic-server-operator-techniques.patch
+++ b/Waterfall-Proxy-Patches/0012-Add-basic-server-operator-techniques.patch
@@ -253,7 +253,7 @@ index 0000000000000000000000000000000000000000..8a99463de283645730f4578eb4c38ba3
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 1455814e19fd9fec8a8ca99ccaadeb1a7fc9c610..b4f59a3047f9c90df6e35ed8c4797180dc9c94ed 100644
+index f5c364790be0cb7c36bb249d898385ffe47062c8..b451fcd6c1ef184a179be95e4c257516d7d24d45 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -102,6 +102,9 @@ import com.mrivanplays.ivancord.modules.CommandList;
@@ -287,10 +287,10 @@ index 1455814e19fd9fec8a8ca99ccaadeb1a7fc9c610..b4f59a3047f9c90df6e35ed8c4797180
  
          if ( !Boolean.getBoolean( "net.md_5.bungee.native.disable" ) )
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index b3810efbc4b22e9af74ba3e3a4fa88f16a743fee..751508850249ea57cf93e3bc518e6edc3ab0274a 100644
+index 509ea05c22f1031e52230076ca1ff99fe19dc9a9..11eab5c03db9c25f34c19b8ce5e3e17555f79f19 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -113,6 +113,10 @@ public final class UserConnection implements ProxiedPlayer
+@@ -114,6 +114,10 @@ public final class UserConnection implements ProxiedPlayer
      @Getter
      private Position position;
      // IvanCord end
@@ -301,7 +301,7 @@ index b3810efbc4b22e9af74ba3e3a4fa88f16a743fee..751508850249ea57cf93e3bc518e6edc
      @Getter
      private int compressionThreshold = -1;
      // Used for trying multiple servers in order
-@@ -198,6 +202,9 @@ public final class UserConnection implements ProxiedPlayer
+@@ -199,6 +203,9 @@ public final class UserConnection implements ProxiedPlayer
          {
              forgeClientHandler.setFmlTokenInHandshake( true );
          }
@@ -311,7 +311,7 @@ index b3810efbc4b22e9af74ba3e3a4fa88f16a743fee..751508850249ea57cf93e3bc518e6edc
      }
  
      public void sendPacket(PacketWrapper packet)
-@@ -595,7 +602,15 @@ public final class UserConnection implements ProxiedPlayer
+@@ -607,7 +614,15 @@ public final class UserConnection implements ProxiedPlayer
      @Override
      public boolean hasPermission(String permission)
      {
@@ -328,7 +328,7 @@ index b3810efbc4b22e9af74ba3e3a4fa88f16a743fee..751508850249ea57cf93e3bc518e6edc
      }
  
      @Override
-@@ -817,6 +832,13 @@ public final class UserConnection implements ProxiedPlayer
+@@ -829,6 +844,13 @@ public final class UserConnection implements ProxiedPlayer
          new SoundPlayedEvent( this, position,
                  PlaySound.NAME_FUNCTION.apply( sound, getPendingConnection().getVersion() ), volume, pitch, category.ordinal() ).callEvent();
      }

--- a/Waterfall-Proxy-Patches/0013-Add-option-to-choose-between-reconnect-handlers.patch
+++ b/Waterfall-Proxy-Patches/0013-Add-option-to-choose-between-reconnect-handlers.patch
@@ -183,7 +183,7 @@ index 6de414ca098ea7335e63b6c672f90e4e7240ca58..8da2ff6a2b590968422c23a456552223
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index b4f59a3047f9c90df6e35ed8c4797180dc9c94ed..a6b50b1d64669159206d96d0ce7bf74cebcbc43c 100644
+index b451fcd6c1ef184a179be95e4c257516d7d24d45..9eed56c211e8213af9525cfd5be12ce32f34a11c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -105,6 +105,9 @@ import com.mrivanplays.ivancord.commands.CommandPlugins;

--- a/Waterfall-Proxy-Patches/0015-Add-plugin-disable-api.patch
+++ b/Waterfall-Proxy-Patches/0015-Add-plugin-disable-api.patch
@@ -194,7 +194,7 @@ index b60c0960dae4a32eb942a5f4d0c66ea1d0d7bb0f..d298d2823bcc8bd4441ad9b01ff94967
 +    // IvanCord end
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index a6b50b1d64669159206d96d0ce7bf74cebcbc43c..c2b7ce3767c949de6c7015d8d7db427fbd6fd45b 100644
+index 9eed56c211e8213af9525cfd5be12ce32f34a11c..6695bf151f78e5ea17b212d81c1f0fd00de27c7c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -523,26 +523,12 @@ public class BungeeCord extends ProxyServer

--- a/Waterfall-Proxy-Patches/0016-Remove-some-of-the-TODOs.patch
+++ b/Waterfall-Proxy-Patches/0016-Remove-some-of-the-TODOs.patch
@@ -104,10 +104,10 @@ index eb435bec0d69ef86c7391565e2197a439a1688cb..c23a7b0d786be236fafabbf795709c66
          user.getPendingConnects().remove( target );
          user.setServerJoinQueue( null );
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 1efdc559d3c90063946fe38d1ad4e53a99eb198a..d15adb3967bab45a2901618a80c14c2ae2500054 100644
+index 30e6cc6552a134bc5358414cbc93368f9bf63ca0..73e174a1b0c26c978373afea7fe437b743f28899 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -35,6 +35,7 @@ import net.md_5.bungee.protocol.packet.PluginMessage;
+@@ -34,6 +34,7 @@ import net.md_5.bungee.protocol.packet.PluginMessage;
  import net.md_5.bungee.protocol.packet.TabCompleteRequest;
  import net.md_5.bungee.protocol.packet.TabCompleteResponse;
  import com.mrivanplays.ivancord.api.Position; // IvanCord
@@ -115,7 +115,7 @@ index 1efdc559d3c90063946fe38d1ad4e53a99eb198a..d15adb3967bab45a2901618a80c14c2a
  
  public class UpstreamBridge extends PacketHandler
  {
-@@ -74,9 +75,9 @@ public class UpstreamBridge extends PacketHandler
+@@ -73,9 +74,9 @@ public class UpstreamBridge extends PacketHandler
              // Manually remove from everyone's tab list
              // since the packet from the server arrives
              // too late
@@ -128,7 +128,7 @@ index 1efdc559d3c90063946fe38d1ad4e53a99eb198a..d15adb3967bab45a2901618a80c14c2a
              PlayerListItem packet = new PlayerListItem();
              packet.setAction( PlayerListItem.Action.REMOVE_PLAYER );
              PlayerListItem.Item item = new PlayerListItem.Item();
-@@ -89,6 +90,7 @@ public class UpstreamBridge extends PacketHandler
+@@ -88,6 +89,7 @@ public class UpstreamBridge extends PacketHandler
              {
                  player.unsafe().sendPacket( packet );
              }

--- a/Waterfall-Proxy-Patches/0018-Add-services-manager.patch
+++ b/Waterfall-Proxy-Patches/0018-Add-services-manager.patch
@@ -536,7 +536,7 @@ index 0000000000000000000000000000000000000000..96063a5982f7f403c3f26998542517e1
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index c2b7ce3767c949de6c7015d8d7db427fbd6fd45b..c8a2e9dc7aca2d92121c063e0fd856f2f46f1269 100644
+index 6695bf151f78e5ea17b212d81c1f0fd00de27c7c..f8e02050faf408392e9463443dd057b99da256af 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -108,6 +108,8 @@ import com.mrivanplays.ivancord.commands.op.CommandOp;

--- a/Waterfall-Proxy-Patches/0019-Add-OfflinePlayer-concept.patch
+++ b/Waterfall-Proxy-Patches/0019-Add-OfflinePlayer-concept.patch
@@ -483,7 +483,7 @@ index 0000000000000000000000000000000000000000..6326bed99c7f5578e79a0f89ba5ea535
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index c8a2e9dc7aca2d92121c063e0fd856f2f46f1269..115f81121e4bfed63217a525ba6090b3d3a35d18 100644
+index f8e02050faf408392e9463443dd057b99da256af..fe63c5e1a13e54f0fb9af0a6baa7fdc007f25106 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -110,6 +110,8 @@ import com.mrivanplays.ivancord.ReconnectHandlerType;
@@ -504,7 +504,7 @@ index c8a2e9dc7aca2d92121c063e0fd856f2f46f1269..115f81121e4bfed63217a525ba6090b3
      // IvanCord end
  
      {
-@@ -863,4 +867,24 @@ public class BungeeCord extends ProxyServer
+@@ -868,4 +872,24 @@ public class BungeeCord extends ProxyServer
      {
          return new BungeeTitle();
      }
@@ -530,10 +530,10 @@ index c8a2e9dc7aca2d92121c063e0fd856f2f46f1269..115f81121e4bfed63217a525ba6090b3
 +    // IvanCord end
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index d15adb3967bab45a2901618a80c14c2ae2500054..7e5eafbe822a320a6464afa360ba3f3a00afcf7a 100644
+index 73e174a1b0c26c978373afea7fe437b743f28899..e0fa14cfca0fc160851b9fd3054170a97ac5e65a 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -69,6 +69,9 @@ public class UpstreamBridge extends PacketHandler
+@@ -68,6 +68,9 @@ public class UpstreamBridge extends PacketHandler
          bungee.getPluginManager().callEvent( event );
          con.getTabListHandler().onDisconnect();
          BungeeCord.getInstance().removeConnection( con );

--- a/Waterfall-Proxy-Patches/0022-Add-attributes-api.patch
+++ b/Waterfall-Proxy-Patches/0022-Add-attributes-api.patch
@@ -368,7 +368,7 @@ index c23a7b0d786be236fafabbf795709c6685fad6df..2a8ddbdb2254d27419fce46d41c5bbbd
              user.unsafe().sendPacket( new EntityStatus( user.getClientEntityId(), login.isReducedDebugInfo() ? EntityStatus.DEBUG_INFO_REDUCED : EntityStatus.DEBUG_INFO_NORMAL ) );
              // And immediate respawn
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 751508850249ea57cf93e3bc518e6edc3ab0274a..624ec8b9348e743003404b42cc376cd511e9c27b 100644
+index 11eab5c03db9c25f34c19b8ce5e3e17555f79f19..0c2480068e401a986dfd50d8e86faa0c48f249a8 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 @@ -4,6 +4,8 @@ import com.google.common.base.Preconditions;
@@ -380,7 +380,7 @@ index 751508850249ea57cf93e3bc518e6edc3ab0274a..624ec8b9348e743003404b42cc376cd5
  import io.netty.bootstrap.Bootstrap;
  import io.netty.channel.Channel;
  import io.netty.channel.ChannelFuture;
-@@ -13,10 +15,12 @@ import io.netty.channel.ChannelOption;
+@@ -14,10 +16,12 @@ import io.netty.channel.ConnectTimeoutException;
  import io.netty.util.internal.PlatformDependent;
  import java.net.InetSocketAddress;
  import java.net.SocketAddress;
@@ -393,7 +393,7 @@ index 751508850249ea57cf93e3bc518e6edc3ab0274a..624ec8b9348e743003404b42cc376cd5
  import java.util.Locale;
  import java.util.Map;
  import java.util.Objects;
-@@ -57,6 +61,7 @@ import net.md_5.bungee.protocol.Protocol;
+@@ -58,6 +62,7 @@ import net.md_5.bungee.protocol.Protocol;
  import net.md_5.bungee.protocol.ProtocolConstants;
  import net.md_5.bungee.protocol.packet.Chat;
  import net.md_5.bungee.protocol.packet.ClientSettings;
@@ -401,7 +401,7 @@ index 751508850249ea57cf93e3bc518e6edc3ab0274a..624ec8b9348e743003404b42cc376cd5
  import net.md_5.bungee.protocol.packet.Kick;
  import net.md_5.bungee.protocol.packet.PlaySound; // IvanCord
  import net.md_5.bungee.protocol.packet.PlayerListHeaderFooter;
-@@ -117,6 +122,10 @@ public final class UserConnection implements ProxiedPlayer
+@@ -118,6 +123,10 @@ public final class UserConnection implements ProxiedPlayer
      @Getter
      private boolean globalOp;
      // IvanCord end
@@ -412,7 +412,7 @@ index 751508850249ea57cf93e3bc518e6edc3ab0274a..624ec8b9348e743003404b42cc376cd5
      @Getter
      private int compressionThreshold = -1;
      // Used for trying multiple servers in order
-@@ -839,6 +848,42 @@ public final class UserConnection implements ProxiedPlayer
+@@ -851,6 +860,42 @@ public final class UserConnection implements ProxiedPlayer
          BungeeCord.getInstance().getOpsConfiguration().setOp( getUniqueId(), globalOp );
          this.globalOp = globalOp;
      }
@@ -456,7 +456,7 @@ index 751508850249ea57cf93e3bc518e6edc3ab0274a..624ec8b9348e743003404b42cc376cd5
  
      // IvanCord start - comment this. Not used anywhere, so...
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 7e5eafbe822a320a6464afa360ba3f3a00afcf7a..1d1c89b58beca05802d970f997484f82a1de2331 100644
+index e0fa14cfca0fc160851b9fd3054170a97ac5e65a..ca2ac32437f1ca4596e1a35343e0078cb78146e3 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 @@ -4,6 +4,9 @@ import com.google.common.base.Preconditions;
@@ -466,10 +466,10 @@ index 7e5eafbe822a320a6464afa360ba3f3a00afcf7a..1d1c89b58beca05802d970f997484f82
 +import com.mrivanplays.ivancord.api.attributes.Attribute;
 +import com.mrivanplays.ivancord.api.attributes.AttributeKey;
 +import com.mrivanplays.ivancord.api.attributes.AttributeModifier;
- import io.github.waterfallmc.waterfall.StringUtil;
  import io.netty.channel.Channel;
  import java.util.ArrayList;
-@@ -28,6 +31,7 @@ import net.md_5.bungee.protocol.PacketWrapper;
+ import java.util.LinkedList;
+@@ -27,6 +30,7 @@ import net.md_5.bungee.protocol.PacketWrapper;
  import net.md_5.bungee.protocol.ProtocolConstants;
  import net.md_5.bungee.protocol.packet.Chat;
  import net.md_5.bungee.protocol.packet.ClientSettings;
@@ -477,7 +477,7 @@ index 7e5eafbe822a320a6464afa360ba3f3a00afcf7a..1d1c89b58beca05802d970f997484f82
  import net.md_5.bungee.protocol.packet.KeepAlive;
  import net.md_5.bungee.protocol.packet.PlayerListItem;
  import net.md_5.bungee.protocol.packet.PlayerPosition;
-@@ -292,6 +296,26 @@ public class UpstreamBridge extends PacketHandler
+@@ -302,6 +306,26 @@ public class UpstreamBridge extends PacketHandler
      }
      // IvanCord end
  

--- a/Waterfall-Proxy-Patches/0024-Reduce-load-on-bungee-by-so-called-BungeeSmasher-s.patch
+++ b/Waterfall-Proxy-Patches/0024-Reduce-load-on-bungee-by-so-called-BungeeSmasher-s.patch
@@ -5,56 +5,8 @@ Subject: [PATCH] Reduce load on bungee by so-called "BungeeSmasher"s
 
 Co-Authored by: MrIvanPlays <ivan@mrivanplays.com> - ported to IvanCord
 
-diff --git a/native/src/main/java/net/md_5/bungee/jni/NativeCode.java b/native/src/main/java/net/md_5/bungee/jni/NativeCode.java
-index a6d7cfb518420f18fd6466b892447b1462ee5201..67315501a343ffaeff2d7e87b6453a2dcb03d4b0 100644
---- a/native/src/main/java/net/md_5/bungee/jni/NativeCode.java
-+++ b/native/src/main/java/net/md_5/bungee/jni/NativeCode.java
-@@ -12,12 +12,21 @@ public final class NativeCode<T>
- {
- 
-     private final String name;
-+    /* // IvanCord start
-     private final Class<? extends T> javaImpl;
-     private final Class<? extends T> nativeImpl;
-+     */
-+    private final java.util.function.Supplier<? extends T> javaImpl;
-+    private final java.util.function.Supplier<? extends T> nativeImpl;
-+    // IvanCord end
-     //
-     private boolean loaded;
- 
-+    /* // IvanCord start
-     public NativeCode(String name, Class<? extends T> javaImpl, Class<? extends T> nativeImpl)
-+     */
-+    public NativeCode(String name, java.util.function.Supplier<? extends T> javaImpl, java.util.function.Supplier<? extends T> nativeImpl)
-+    // IvanCord end
-     {
-         if ("Mac OS X".equals( System.getProperty( "os.name" ))) name = "osx-" + name; // Waterfall
-         this.name = name;
-@@ -27,13 +36,21 @@ public final class NativeCode<T>
- 
-     public T newInstance()
-     {
-+        // IvanCord start
-+        /*
-         try
-         {
-+         */
-+            /*
-             return ( loaded ) ? nativeImpl.getDeclaredConstructor().newInstance() : javaImpl.getDeclaredConstructor().newInstance();
-+             */
-+            return ( loaded ) ? nativeImpl.get() : javaImpl.get();
-+            /*
-         } catch ( ReflectiveOperationException ex )
-         {
-             throw new RuntimeException( "Error getting instance", ex );
-         }
-+             */ // IvanCord end
-     }
- 
-     public boolean load()
 diff --git a/native/src/main/java/net/md_5/bungee/jni/cipher/JavaCipher.java b/native/src/main/java/net/md_5/bungee/jni/cipher/JavaCipher.java
-index d211cef6d592d7857f0ba828a78c547b7927f40b..f9b31f496c1839f56f7860f4fd548f8ad7f87f96 100644
+index 0e27c2d7e57ca6285df21ab126b3283e6ebd9287..8e5efc4ac0a75687673c012c8ab9ef3ae9f3d0e7 100644
 --- a/native/src/main/java/net/md_5/bungee/jni/cipher/JavaCipher.java
 +++ b/native/src/main/java/net/md_5/bungee/jni/cipher/JavaCipher.java
 @@ -11,7 +11,7 @@ import javax.crypto.spec.IvParameterSpec;
@@ -66,14 +18,17 @@ index d211cef6d592d7857f0ba828a78c547b7927f40b..f9b31f496c1839f56f7860f4fd548f8a
      private static final ThreadLocal<byte[]> heapInLocal = new EmptyByteThreadLocal();
      private static final ThreadLocal<byte[]> heapOutLocal = new EmptyByteThreadLocal();
  
-@@ -25,14 +25,17 @@ public class JavaCipher implements BungeeCipher
+@@ -25,6 +25,7 @@ public class JavaCipher implements BungeeCipher
          }
      }
  
 +    /* // IvanCord start
-     public JavaCipher() throws GeneralSecurityException
+     public JavaCipher()
      {
-         this.cipher = Cipher.getInstance( "AES/CFB8/NoPadding" );
+         try
+@@ -35,10 +36,12 @@ public class JavaCipher implements BungeeCipher
+             throw new RuntimeException( ex );
+         }
      }
 +     */ // IvanCord end
  
@@ -84,34 +39,8 @@ index d211cef6d592d7857f0ba828a78c547b7927f40b..f9b31f496c1839f56f7860f4fd548f8a
          int mode = forEncryption ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE;
          cipher.init( mode, key, new IvParameterSpec( key.getEncoded() ) );
      }
-diff --git a/native/src/test/java/net/md_5/bungee/NativeCipherTest.java b/native/src/test/java/net/md_5/bungee/NativeCipherTest.java
-index 72b81ab87ad600857dd625727449a45832e18f67..1b7ff35b0d6534bbf12a30c235319604f505f7c5 100644
---- a/native/src/test/java/net/md_5/bungee/NativeCipherTest.java
-+++ b/native/src/test/java/net/md_5/bungee/NativeCipherTest.java
-@@ -26,7 +26,7 @@ public class NativeCipherTest
-     private final SecretKey secret = new SecretKeySpec( new byte[ 16 ], "AES" );
-     private static final int BENCHMARK_COUNT = 4096;
-     //
--    private static final NativeCode<BungeeCipher> factory = new NativeCode<>( "native-cipher", JavaCipher.class, NativeCipher.class );
-+    private static final NativeCode<BungeeCipher> factory = new NativeCode<>( "native-cipher", JavaCipher::new, NativeCipher::new ); // IvanCord
- 
-     @Test
-     public void testNative() throws Exception
-diff --git a/native/src/test/java/net/md_5/bungee/NativeZlibTest.java b/native/src/test/java/net/md_5/bungee/NativeZlibTest.java
-index fde626b1ac777f14600eb052f36cb4b11fa8044c..e64ea66b1e7de49834bed0b7d195e084ec3f77ca 100644
---- a/native/src/test/java/net/md_5/bungee/NativeZlibTest.java
-+++ b/native/src/test/java/net/md_5/bungee/NativeZlibTest.java
-@@ -15,7 +15,7 @@ import org.junit.Test;
- public class NativeZlibTest
- {
- 
--    private final NativeCode<BungeeZlib> factory = new NativeCode<>( "native-compress", JavaZlib.class, NativeZlib.class );
-+    private final NativeCode<BungeeZlib> factory = new NativeCode<>( "native-compress", JavaZlib::new, NativeZlib::new ); // IvanCord
- 
-     @Test
-     public void doTest() throws DataFormatException
 diff --git a/pom.xml b/pom.xml
-index 77dd0268ea2c9fa1fb8bb6344f358f93ce3c5e4c..1df910903f5ce6076ea570c07dd18c156b6a6f17 100644
+index 73fd6bbfee16bb9354e2e6bbb370d720ad946903..72dc24400c4c45f9bc76e15c6af68298a39fa754 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -47,6 +47,7 @@
@@ -290,7 +219,7 @@ index 4578ba40a4ca2e7ad0a7909e248221ff8c7a9aa1..c4e00d9079d72cafdffeb50f91458288
  
      <build>
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 115f81121e4bfed63217a525ba6090b3d3a35d18..432cfcf096a3c3ccb87b896fd9e55cbe1c89d87e 100644
+index fe63c5e1a13e54f0fb9af0a6baa7fdc007f25106..902d9986cf80fa351f4e953feefdca5d722d191f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -420,7 +420,7 @@ public class BungeeCord extends ProxyServer
@@ -337,24 +266,11 @@ index 35d533252b7009bd5f4c14b265cea0bc05f11b91..25c321a1bc62b969839cc0a2462fbbf4
                  .build( new CacheLoader<InetAddress, AtomicInteger>()
                  {
                      @Override
-diff --git a/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java b/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
-index ff6bb8c16d4c399cbbf933e4b706fd9bf17127b5..2f41e77085a11ca5004dafc78cc5f3333331d9c7 100644
---- a/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
-+++ b/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
-@@ -31,7 +31,7 @@ public class EncryptionUtil
-     public static final KeyPair keys;
-     @Getter
-     private static final SecretKey secret = new SecretKeySpec( new byte[ 16 ], "AES" );
--    public static final NativeCode<BungeeCipher> nativeFactory = new NativeCode<>( "native-cipher", JavaCipher.class, NativeCipher.class );
-+    public static final NativeCode<BungeeCipher> nativeFactory = new NativeCode<>( "native-cipher", JavaCipher::new, NativeCipher::new ); // IvanCord
- 
-     static
-     {
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 624ec8b9348e743003404b42cc376cd511e9c27b..309e70d1be8b7898eaf3619a7464ddb641173860 100644
+index 0c2480068e401a986dfd50d8e86faa0c48f249a8..6d6e12ecbf8d86fd88fbe0a549c04c09ad73c7d7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -417,7 +417,7 @@ public final class UserConnection implements ProxiedPlayer
+@@ -418,7 +418,7 @@ public final class UserConnection implements ProxiedPlayer
              }
          };
          Bootstrap b = new Bootstrap()
@@ -363,19 +279,8 @@ index 624ec8b9348e743003404b42cc376cd511e9c27b..309e70d1be8b7898eaf3619a7464ddb6
                  .group( ch.getHandle().eventLoop() )
                  .handler( initializer )
                  .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, request.getConnectTimeout() )
-diff --git a/proxy/src/main/java/net/md_5/bungee/compress/CompressFactory.java b/proxy/src/main/java/net/md_5/bungee/compress/CompressFactory.java
-index 1f2d5a70aa660d97aa95e28d35702efed3898eaa..0747afe9803977e53c43b208c69f5c0bc95a636c 100644
---- a/proxy/src/main/java/net/md_5/bungee/compress/CompressFactory.java
-+++ b/proxy/src/main/java/net/md_5/bungee/compress/CompressFactory.java
-@@ -8,5 +8,5 @@ import net.md_5.bungee.jni.zlib.NativeZlib;
- public class CompressFactory
- {
- 
--    public static final NativeCode<BungeeZlib> zlib = new NativeCode<>( "native-compress", JavaZlib.class, NativeZlib.class );
-+    public static final NativeCode<BungeeZlib> zlib = new NativeCode<>( "native-compress", JavaZlib::new, NativeZlib::new ); // IvanCord
- }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index ee1fcad3185cc9c0db40a2d58e28fdc07ab3b8ce..2fc8bf6600f752aca94788dee2808c0a400de702 100644
+index f7331736e2cd604f35011a5ed8b0ab4cd8ba9374..fb6c7282ffe16f700fe2ab2ea714f92335dcd72e 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 @@ -140,9 +140,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
@@ -416,7 +321,7 @@ index ee1fcad3185cc9c0db40a2d58e28fdc07ab3b8ce..2fc8bf6600f752aca94788dee2808c0a
          }
      }
  
-@@ -702,4 +705,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -696,4 +699,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      {
          return !ch.isClosed();
      }
@@ -478,7 +383,7 @@ index d45a6140780f592d9f8c67cf2f7cb83496a14681..9d768f9bd262bb87e904f8b35a5d2978
      {
          if ( !closed && ch.isActive() ) // IvanCord
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
-index 270545f28e299ecd12e76213dbd2a11bcc9701e3..aae1fe508aa24b0b5a3fcd7643b1a50b3bc76009 100644
+index f8d6becd6906554f1c4fa9e0aed785159e26394f..e110a1fbb1aa998cffa207cbd81a4ba079dbf15f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
 @@ -27,6 +27,11 @@ import net.md_5.bungee.util.QuietException;
@@ -493,7 +398,7 @@ index 270545f28e299ecd12e76213dbd2a11bcc9701e3..aae1fe508aa24b0b5a3fcd7643b1a50b
      private ChannelWrapper channel;
      private PacketHandler handler;
  
-@@ -130,6 +135,22 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
+@@ -133,6 +138,22 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
      {
          if ( ctx.channel().isActive() )
          {
@@ -516,7 +421,7 @@ index 270545f28e299ecd12e76213dbd2a11bcc9701e3..aae1fe508aa24b0b5a3fcd7643b1a50b
              boolean logExceptions = !( handler instanceof PingHandler );
  
              if ( logExceptions )
-@@ -157,6 +178,14 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
+@@ -160,6 +181,14 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                          {
                              handler, cause.getCause().getMessage()
                          } );
@@ -531,7 +436,7 @@ index 270545f28e299ecd12e76213dbd2a11bcc9701e3..aae1fe508aa24b0b5a3fcd7643b1a50b
                      }
                  } else if ( cause instanceof IOException || ( cause instanceof IllegalStateException && handler instanceof InitialHandler ) )
                  {
-@@ -187,7 +216,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
+@@ -190,7 +219,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                  }
              }
  

--- a/Waterfall-Proxy-Patches/0025-Improve-scheduler.patch
+++ b/Waterfall-Proxy-Patches/0025-Improve-scheduler.patch
@@ -140,7 +140,7 @@ index 0000000000000000000000000000000000000000..00ff4769884de0b635144bc7ca134f35
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 432cfcf096a3c3ccb87b896fd9e55cbe1c89d87e..8f452d2cd5ce3512954bd6fac33b8c9ff7398ee7 100644
+index 902d9986cf80fa351f4e953feefdca5d722d191f..a7cba641f1833b80d85f5f251154f1b3f25419eb 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -543,6 +543,17 @@ public class BungeeCord extends ProxyServer

--- a/Waterfall-Proxy-Patches/0026-Brigadier-command-api.patch
+++ b/Waterfall-Proxy-Patches/0026-Brigadier-command-api.patch
@@ -1945,10 +1945,10 @@ index ca7c6342bb678187432adb93aca7b20fbe71a200..3109f17ea0c38de32e31acaf9ae24b4e
          }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 8f452d2cd5ce3512954bd6fac33b8c9ff7398ee7..e959aef1f4258c54e6084c45f51f5cee2e39478e 100644
+index a7cba641f1833b80d85f5f251154f1b3f25419eb..d17dd9db174f8ace4344ad5415bcd42a7d923203 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -897,5 +897,22 @@ public class BungeeCord extends ProxyServer
+@@ -902,5 +902,22 @@ public class BungeeCord extends ProxyServer
      {
          return playerdata.getOfflinePlayers();
      }
@@ -2197,10 +2197,10 @@ index adcd895b423df476ad732c9c64e016f1f6baff4e..87122de04f0bf10a2382776cb575beee
      @Override
      public void handle(PlayerPosition pac)
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 1d1c89b58beca05802d970f997484f82a1de2331..4603408e1af16a2d8e71b08dbc294feb7cc8302a 100644
+index ca2ac32437f1ca4596e1a35343e0078cb78146e3..9708400babb47859fbee4fcc65988c27524bda1b 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -193,6 +193,87 @@ public class UpstreamBridge extends PacketHandler
+@@ -203,6 +203,87 @@ public class UpstreamBridge extends PacketHandler
          }
  
          // Waterfall end - tab limiter
@@ -2288,7 +2288,7 @@ index 1d1c89b58beca05802d970f997484f82a1de2331..4603408e1af16a2d8e71b08dbc294feb
          List<String> suggestions = new ArrayList<>();
  
          if ( tabComplete.getCursor().startsWith( "/" ) )
-@@ -232,6 +313,7 @@ public class UpstreamBridge extends PacketHandler
+@@ -242,6 +323,7 @@ public class UpstreamBridge extends PacketHandler
              }
              throw CancelSendSignal.INSTANCE;
          }
@@ -2297,11 +2297,11 @@ index 1d1c89b58beca05802d970f997484f82a1de2331..4603408e1af16a2d8e71b08dbc294feb
  
      @Override
 diff --git a/proxy/src/main/resources/messages.properties b/proxy/src/main/resources/messages.properties
-index 55493ee39edcbd362ae43d7c748cadf80c98e7ab..f14b215e742b428cad5d7a087712244a7bbc0c74 100644
+index 35c2b9ff046eac2c20e5f66eb71b962a14ebda4a..31661e1831f611af0f404032372a4dfedeba4d8d 100644
 --- a/proxy/src/main/resources/messages.properties
 +++ b/proxy/src/main/resources/messages.properties
-@@ -40,3 +40,5 @@ command_perms_permission=\u00a79- {0}
- command_ip=\u00a79IP of {0} is {1}
+@@ -41,3 +41,5 @@ command_ip=\u00a79IP of {0} is {1}
+ illegal_chat_characters=\u00a7cillegal characters in chat ({0})
  kick_to_lobby=You were kicked from server {0} with reason {1} . The fallback sent you to {2}
  command_plugins_message=Plugins ({0}): {1}
 +internal_error_executing=\u00a7cAn internal error occurred whilst executing this command, please check the console log for details.

--- a/Waterfall-Proxy-Patches/0027-Fix-infinite-relay-message-accumulation.patch
+++ b/Waterfall-Proxy-Patches/0027-Fix-infinite-relay-message-accumulation.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix infinite relay message accumulation
 Co-authored-by: Ivan Pekov <ivan@mrivanplays.com>
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 2fc8bf6600f752aca94788dee2808c0a400de702..bbe59d7528dc68fbeac1b2b357a78204b5d31b46 100644
+index fb6c7282ffe16f700fe2ab2ea714f92335dcd72e..830504439884cb4901666c417420d3df999ba969 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 @@ -164,7 +164,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
@@ -19,10 +19,10 @@ index 2fc8bf6600f752aca94788dee2808c0a400de702..bbe59d7528dc68fbeac1b2b357a78204
              relayMessages.add( pluginMessage );
          }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 4603408e1af16a2d8e71b08dbc294feb7cc8302a..4e8644e05f81dcd268ea245b11b3cd40d0455f87 100644
+index 9708400babb47859fbee4fcc65988c27524bda1b..fb373250a6f8a46adf9b207ba92f7a7fe0d1a83d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -364,7 +364,7 @@ public class UpstreamBridge extends PacketHandler
+@@ -374,7 +374,7 @@ public class UpstreamBridge extends PacketHandler
          }
  
          // TODO: Unregister as well?

--- a/Waterfall-Proxy-Patches/0028-Use-the-new-ActionBar-packet-to-send-action-bars-for.patch
+++ b/Waterfall-Proxy-Patches/0028-Use-the-new-ActionBar-packet-to-send-action-bars-for.patch
@@ -98,10 +98,10 @@ index 0000000000000000000000000000000000000000..c553ba02d7f13c83f72f5e016bda8281
 +}
 +// IvanCord end
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 309e70d1be8b7898eaf3619a7464ddb641173860..235986985739b1cf3da5fa7ed1a4c4a688b12d8f 100644
+index 6d6e12ecbf8d86fd88fbe0a549c04c09ad73c7d7..92670810fd5d8ae4dbbc60e794110b8cce089d6c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -538,13 +538,17 @@ public final class UserConnection implements ProxiedPlayer
+@@ -550,13 +550,17 @@ public final class UserConnection implements ProxiedPlayer
          // transform score components
          message = ChatComponentTransformer.getInstance().transform( this, true, message );
  

--- a/Waterfall-Proxy-Patches/0029-EventBus-speed-improvements.patch
+++ b/Waterfall-Proxy-Patches/0029-EventBus-speed-improvements.patch
@@ -309,7 +309,7 @@ index ad19c020c77a45c3b3a8a18aaf2f59c2de15ec7c..9b6977e4e60ee25f49779ba304631def
  }
 diff --git a/event/src/test/java/com/mrivanplays/ivancord/event/NonVoidReturnTypeTest.java b/event/src/test/java/com/mrivanplays/ivancord/event/NonVoidReturnTypeTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..aa05d38188d9867c8bc10a775e37be13c1e26bfd
+index 0000000000000000000000000000000000000000..5cb048ee2e4d9d4c6137f1e99312b83ee92d808c
 --- /dev/null
 +++ b/event/src/test/java/com/mrivanplays/ivancord/event/NonVoidReturnTypeTest.java
 @@ -0,0 +1,46 @@
@@ -361,7 +361,7 @@ index 0000000000000000000000000000000000000000..aa05d38188d9867c8bc10a775e37be13
 +}
 diff --git a/proxy/src/main/java/com/mrivanplays/ivancord/eventcaller/EventCaller.java b/proxy/src/main/java/com/mrivanplays/ivancord/eventcaller/EventCaller.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..86e9ac96b7448d607ff0c002b2e04ba432d17e8a
+index 0000000000000000000000000000000000000000..6d0ebe536ffc49d48291ec7db68896ac872669f0
 --- /dev/null
 +++ b/proxy/src/main/java/com/mrivanplays/ivancord/eventcaller/EventCaller.java
 @@ -0,0 +1,17 @@
@@ -383,7 +383,7 @@ index 0000000000000000000000000000000000000000..86e9ac96b7448d607ff0c002b2e04ba4
 +    public static final MethodHandles.Lookup lookup = MethodHandles.lookup();
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index e959aef1f4258c54e6084c45f51f5cee2e39478e..3c389b409f9d879fc9e267e2620e9890afa463a3 100644
+index d17dd9db174f8ace4344ad5415bcd42a7d923203..9e5bf43c95b562afdbb19f1410a59df7f0ef4ecb 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -257,7 +257,7 @@ public class BungeeCord extends ProxyServer
@@ -397,7 +397,7 @@ index e959aef1f4258c54e6084c45f51f5cee2e39478e..3c389b409f9d879fc9e267e2620e9890
          getPluginManager().registerCommand( null, new CommandIP() );
 diff --git a/proxy/src/main/java/net/md_5/bungee/api/plugin/EventCallerClassLoader.java b/proxy/src/main/java/net/md_5/bungee/api/plugin/EventCallerClassLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d517c7df73e419b37a9aec333977fe00a727dd61
+index 0000000000000000000000000000000000000000..1e56ef1d27ec59eaa8ada276d373badbca8751dd
 --- /dev/null
 +++ b/proxy/src/main/java/net/md_5/bungee/api/plugin/EventCallerClassLoader.java
 @@ -0,0 +1,118 @@


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly.
This update has not been tested by MrIvanPlays and as with ANY update, please do your own testing

Waterfall Changes:
7e6af4c Strip hostname from InetSocketAddress (#679)
9137560 Updated Upstream (BungeeCord) (#678)
7196e44 Don't spam github actions log with maven progress (#662)
f17de74 remove 4MB buffer size limit due to protocol changes
dc044fb Don't bother locking to fetch a v4 UUID from the offline UUIDs map
9dd430a Updated Upstream (BungeeCord) (#667)
a5c78a9 (Maybe) Fix javadoc search
eb920b8 Updated Upstream (BungeeCord)
8e9b90a fix compile-native not working on linux
ee819df Updated Upstream (BungeeCord)
66601f7 [ci skip] link to javadocs page instead of attempting direct